### PR TITLE
leverage source org from list instead of var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gh-migrate-customproperties
 
-A GitHub CLI extension that helps migrate repository custom properties from one organization to another. It supports both GitHub.com and GitHub Enterprise Server environments for source.
+A GitHub CLI extension that helps migrate repository custom properties from one organization to another. It supports both GitHub.com and GitHub Enterprise Server environments.
+
 
 ## Installation
 
@@ -22,20 +23,26 @@ gh extension upgrade gh-migrate-customproperties
 gh migrate-customproperties [flags]
 
 Flags:
-  -s, --source-organization string   Source Organization to sync custom properties from
-  -t, --target-organization string   Target Organization to sync custom properties to
+  -t, --target-organization string   Target Organization to sync properties to
   -a, --source-token string         Source Organization GitHub token. Required scopes: read:org, read:user, user:email
   -b, --target-token string         Target Organization GitHub token. Required scopes: admin:org
   -u, --source-hostname string      GitHub Enterprise source hostname url (optional) Ex. https://github.example.com
   -r, --repository-list string      File containing list of repositories to sync properties from. One repository per line.
 ```
 
-### Example repository list file format
+### Repository List Format
 
-The repository list file (`--repository-list`) should contain one repository per line and supports the following formats:
-- Full URLs: `https://github.com/org/repo1` (the `source-organization` and `source-hostname` value will be used for the org and hostname respectively)
-- Simple org/repo format: `org/repo1` (the `source-organization` value will be used for the org)
-- Just repository names: `repo1`
+The repository list file (`--repository-list`) must contain repositories in either of these formats:
+- Full URLs: `https://github.com/owner/repo`
+- Owner/repo format: `owner/repo`
+
+Example repository list:
+```
+octocat/Hello-World
+https://github.com/mona/awesome-project
+```
+
+Note: Simple repository names without owner are no longer supported. Each entry must specify both the owner and repository name.
 
 ## License
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,15 +15,11 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "gh-migrate-customproperties",
 	Short: "help migrate repo custom properties",
-	Long: `This is a migration CLI extension that can provides additional capabilities to migrate
+	Long: `This is a migration CLI extension that provides additional capabilities to migrate
 	repositories with custom properties from one organization to another.
 	`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
 	Run: func(cmd *cobra.Command, args []string) {
-
 		// Get parameters
-		sourceOrganization := cmd.Flag("source-organization").Value.String()
 		targetOrganization := cmd.Flag("target-organization").Value.String()
 		sourceToken := cmd.Flag("source-token").Value.String()
 		targetToken := cmd.Flag("target-token").Value.String()
@@ -31,7 +27,6 @@ var rootCmd = &cobra.Command{
 		repositoryList := cmd.Flag("repository-list").Value.String()
 
 		// Set ENV variables
-		os.Setenv("GHMC_SOURCE_ORGANIZATION", sourceOrganization)
 		os.Setenv("GHMC_TARGET_ORGANIZATION", targetOrganization)
 		os.Setenv("GHMC_SOURCE_TOKEN", sourceToken)
 		os.Setenv("GHMC_TARGET_TOKEN", targetToken)
@@ -39,7 +34,6 @@ var rootCmd = &cobra.Command{
 		os.Setenv("GHMC_REPOSITORY_LIST", repositoryList)
 
 		// Bind ENV variables in Viper
-		viper.BindEnv("SOURCE_ORGANIZATION")
 		viper.BindEnv("TARGET_ORGANIZATION")
 		viper.BindEnv("SOURCE_TOKEN")
 		viper.BindEnv("TARGET_TOKEN")
@@ -73,11 +67,7 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-
-	rootCmd.Flags().StringP("source-organization", "s", "", "Source Organization to sync teams from")
-	rootCmd.MarkFlagRequired("source-organization")
-
-	rootCmd.Flags().StringP("target-organization", "t", "", "Target Organization to sync teams from")
+	rootCmd.Flags().StringP("target-organization", "t", "", "Target Organization to sync properties to")
 	rootCmd.MarkFlagRequired("target-organization")
 
 	rootCmd.Flags().StringP("source-token", "a", "", "Source Organization GitHub token. Scopes: read:org, read:user, user:email")
@@ -88,8 +78,9 @@ func init() {
 
 	rootCmd.Flags().StringP("source-hostname", "u", "", "GitHub Enterprise source hostname url (optional) Ex. https://github.example.com")
 
-	rootCmd.Flags().StringP("repository-list", "r", "", "File containing list of repositories to sync properties from. One repository per line. Ex. reponame")
+	rootCmd.Flags().StringP("repository-list", "r", "", "File containing list of repositories to sync properties from. One repository per line. Must be in owner/repo format.")
 	rootCmd.MarkFlagRequired("repository-list")
+
 	viper.SetEnvPrefix("GHMC") // GHMigrateCustomProperties
 
 	// Read in environment variables that match

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -17,7 +17,7 @@ func TestParseRepositoryFile(t *testing.T) {
 		{
 			name:      "valid repositories with full URLs",
 			content:   "https://github.com/org/repo1\nhttps://github.com/org/repo2\nhttps://github.com/different-org/repo3",
-			wantRepos: []string{"repo1", "repo2", "repo3"},
+			wantRepos: []string{"org/repo1", "org/repo2", "different-org/repo3"},
 			wantErr:   false,
 		},
 		{
@@ -32,25 +32,20 @@ func TestParseRepositoryFile(t *testing.T) {
 			content:     "https://github.com/org/repo1\n:invalid:\nhttps://github.com/org/repo3",
 			wantRepos:   nil,
 			wantErr:     true,
-			errContains: "invalid URI",
+			errContains: "invalid repository format",
 		},
 		{
 			name:      "simple owner/repo format",
 			content:   "org/repo1\nother-org/repo2",
-			wantRepos: []string{"repo1", "repo2"},
+			wantRepos: []string{"org/repo1", "other-org/repo2"},
 			wantErr:   false,
 		},
 		{
-			name:      "mixed formats",
-			content:   "org/repo1\nhttps://github.com/org/repo2\nrepo3",
-			wantRepos: []string{"repo1", "repo2", "repo3"},
-			wantErr:   false,
-		},
-		{
-			name:      "just repo names",
-			content:   "repo1\nrepo2\nrepo3",
-			wantRepos: []string{"repo1", "repo2", "repo3"},
-			wantErr:   false,
+			name:        "repository without owner",
+			content:     "repo1\nrepo2\nrepo3",
+			wantRepos:   nil,
+			wantErr:     true,
+			errContains: "must be in the format 'owner/repo'",
 		},
 	}
 


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

This pull request includes several changes to improve the functionality and usability of the `gh-migrate-customproperties` GitHub CLI extension. The most important changes include updates to the repository list format, removal of source-organization flags, as now the source organization is take from the repository list provided.

## Checklist

<!-- - [ ] Issue linked if existing -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R4): Updated the description and clarified the repository list format by removing support for simple repository names without owners. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R45)

Flag Descriptions:
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL18-L42): Removed the `source-organization` flag and updated the description for the `target-organization` and `repository-list` flags to reflect the new requirements. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL18-L42) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL76-R70) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL91-R83)

Repository Parsing:
* [`internal/file/file.go`](diffhunk://#diff-f592681857cdc105f27572fb3771a4e92b3096efc070ddbab47195b8230f1b90L22-R51): Improved the `ParseRepositoryFile` function to handle only full URLs and owner/repo formats, and updated corresponding tests. [[1]](diffhunk://#diff-f592681857cdc105f27572fb3771a4e92b3096efc070ddbab47195b8230f1b90L22-R51) [[2]](diffhunk://#diff-ea1b8acf4410716165015c6bbf8c825474672dfb0afa82668ae0320775493b17L20-R20) [[3]](diffhunk://#diff-ea1b8acf4410716165015c6bbf8c825474672dfb0afa82668ae0320775493b17L35-R48)

Synchronization Logic:
* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR8): Refined the `SyncRepositoryProperties` function to better handle repository names and improve error logging during fetch and create phases. [[1]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR8) [[2]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befL43) [[3]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befL62) [[4]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befL71) [[5]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befL83-R100) [[6]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befL111-R113)